### PR TITLE
Changes for Command & Permissions

### DIFF
--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -26,9 +26,23 @@ import java.util.*
 @CommandDescription("Provided plugin by LiteEco")
 class MoneyCMD(private val liteEco: LiteEco) {
 
-    @CommandMethod("money|bal|balance [player]")
-    @CommandPermission("lite.eco.money")
-    fun onBalance(commandSender: CommandSender, @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer?) {
+    @CommandMethod("money help")
+    @CommandPermission("lite.eco.help")
+    fun onHelp(commandSender: CommandSender) {
+        liteEco.translationConfig.getList("messages.help")?.forEach { s ->
+            commandSender.sendMessage(ModernText.miniModernText(s.toString()))
+        }
+    }
+
+    @CommandMethod("bal|balance [player]")
+    @CommandPermission("lite.eco.balance")
+    fun onBalanceProxy(commandSender: CommandSender, @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer?) {
+        onBalance(commandSender, offlinePlayer)
+    }
+
+    @CommandMethod("money bal [player]")
+    @CommandPermission("lite.eco.balance")
+    fun onBalance(commandSender: CommandSender, @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer?) {
         if (commandSender is Player) {
             if (offlinePlayer == null) {
                 commandSender.sendMessage(
@@ -115,16 +129,8 @@ class MoneyCMD(private val liteEco: LiteEco) {
         commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.balance_top_line_second")))
     }
 
-    @CommandMethod("money|bal|balance help")
-    @CommandPermission("lite.eco.help")
-    fun onHelp(commandSender: CommandSender) {
-        liteEco.translationConfig.getList("messages.help")?.forEach { s ->
-            commandSender.sendMessage(ModernText.miniModernText(s.toString()))
-        }
-    }
-
     @ProxiedBy("pay")
-    @CommandMethod("money|bal|balance pay <player> <amount>")
+    @CommandMethod("money pay <player> <amount>")
     @CommandPermission("lite.eco.pay")
     fun onPayMoney(
         commandSender: CommandSender,

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -123,14 +123,6 @@ class MoneyCMD(private val liteEco: LiteEco) {
         }
     }
 
-    @CommandMethod("eco adminhelp")
-    @CommandPermission("lite.eco.admin.help")
-    fun adminHelp(commandSender: CommandSender) {
-        liteEco.translationConfig.getList("messages.admin-help")?.forEach { s ->
-            commandSender.sendMessage(ModernText.miniModernText(s.toString()))
-        }
-    }
-
     @ProxiedBy("pay")
     @CommandMethod("money|bal|balance pay <player> <amount>")
     @CommandPermission("lite.eco.pay")
@@ -139,29 +131,35 @@ class MoneyCMD(private val liteEco: LiteEco) {
         @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer,
         @Argument(value = "amount") @Range(min = "1.00", max = "") amount: Double
     ) {
-        if (commandSender !is Player) { // temp fix
-            commandSender.sendMessage(ModernText.miniModernText("<red>TerminalConsoleCommandSender is not allowed to execute that command. Must be of type Player"))
-            return
-        }
-        val player: Player = commandSender
+        if (commandSender is Player) {
+            if (commandSender.name == offlinePlayer.name) {
+                commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.self_pay_error")))
+                return
+            }
 
-        if (player.name == offlinePlayer.name) {
-            player.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.self_pay_error")))
-            return
-        }
+            if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
+                commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
+                return
+            }
 
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
-            player.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
+            liteEco.server.scheduler.runTask(liteEco) { ->
+                liteEco.pluginManger.callEvent(PlayerEconomyPayEvent(commandSender, offlinePlayer, amount))
+            }
+        } else {
+            commandSender.sendMessage(ModernText.miniModernText("<red>Only a player can use this command."))
         }
+    }
 
-        liteEco.server.scheduler.runTask(liteEco) { ->
-            liteEco.pluginManger.callEvent(PlayerEconomyPayEvent(player, offlinePlayer, amount))
+    @CommandMethod("eco help")
+    @CommandPermission("lite.eco.admin.help")
+    fun adminHelp(commandSender: CommandSender) {
+        liteEco.translationConfig.getList("messages.admin-help")?.forEach { s ->
+            commandSender.sendMessage(ModernText.miniModernText(s.toString()))
         }
     }
 
     @CommandMethod("eco add <player> <amount>")
-    @CommandPermission("lite.eco.add")
+    @CommandPermission("lite.eco.admin.add")
     fun onAddMoney(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer,
@@ -179,7 +177,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco gadd <amount>")
-    @CommandPermission("lite.eco.gadd")
+    @CommandPermission("lite.eco.admin.gadd")
     fun onGlobalAddMoney(
         commandSender: CommandSender,
         @Argument("amount") @Range(min = "1.0", max = "") amount: Double
@@ -197,7 +195,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco set <player> <amount>")
-    @CommandPermission("lite.eco.set")
+    @CommandPermission("lite.eco.admin.set")
     fun onSetBalance(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer,
@@ -219,7 +217,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco gset <amount>")
-    @CommandPermission("lite.eco.gset")
+    @CommandPermission("lite.eco.admin.gset")
     fun onGlobalSetMoney(
         commandSender: CommandSender,
         @Argument("amount") @Range(min = "1.0", max = "") amount: Double
@@ -237,7 +235,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco remove <player> <amount>")
-    @CommandPermission("lite.eco.remove")
+    @CommandPermission("lite.eco.admin.remove")
     fun onRemoveMoney(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "offlinePlayers") offlinePlayer: OfflinePlayer,
@@ -261,7 +259,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco gremove <amount>")
-    @CommandPermission("lite.eco.gremove")
+    @CommandPermission("lite.eco.admin.gremove")
     fun onGlobalRemoveMoney(
         commandSender: CommandSender,
         @Argument("amount") @Range(min = "1.0", max = "") amount: Double
@@ -274,7 +272,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco lang <isoKey>")
-    @CommandPermission("lite.eco.lang")
+    @CommandPermission("lite.eco.admin.lang")
     fun onLangSwitch(
         commandSender: CommandSender,
         @Argument(value = "isoKey", suggestions = "translationKeys") translationKey: TranslationKey
@@ -313,7 +311,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco purge [argument]")
-    @CommandPermission("lite.eco.purge")
+    @CommandPermission("lite.eco.admin.purge")
     fun onPurge(commandSender: CommandSender, @Argument(value = "argument", suggestions = "purgeKeys") purgeKey: PurgeKey)
     {
         when (purgeKey) {
@@ -332,7 +330,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     @CommandMethod("eco reload")
-    @CommandPermission("lite.eco.reload")
+    @CommandPermission("lite.eco.admin.reload")
     fun onReload(commandSender: CommandSender) {
         liteEco.reloadConfig()
         commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.config_reload")))

--- a/src/main/resources/locale/translation-CS_CZ.yml
+++ b/src/main/resources/locale/translation-CS_CZ.yml
@@ -34,9 +34,9 @@ messages:
   help:
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="
     - " "
-    - "<white>[+] <gray>/money [username] <white>- <gray>Ukáže stav tvého účtu nebo jiného hráče."
     - "<white>[+] <gray>/money help <white>- <gray>Vypíše příkazy pluginu"
     - "<white>[+] <gray>/money top [page] <white>- <gray>Vypíše nejbohatší hráče"
+    - "<white>[+] <gray>/money bal [username] <white>- <gray>Ukáže stav tvého účtu nebo jiného hráče."
     - "<white>[+] <gray>/money pay <yellow><username> <amount> <white>- <gray>Pošle hráči peníze."
     - " "
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="

--- a/src/main/resources/locale/translation-EN_US.yml
+++ b/src/main/resources/locale/translation-EN_US.yml
@@ -34,9 +34,9 @@ messages:
   help:
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="
     - " "
-    - "<white>[+] <gray>/money [username] <white>- <gray>Show balance of your account or another player"
     - "<white>[+] <gray>/money help <white>- <gray>Show commands list of plugin"
     - "<white>[+] <gray>/money top [page] <white>- <gray>Show richest players"
+    - "<white>[+] <gray>/money bal [username] <white>- <gray>Show balance of your account or another player"
     - "<white>[+] <gray>/money pay <yellow><username> <amount> <white>- <gray>Sent money to another player."
     - " "
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="

--- a/src/main/resources/locale/translation-ES_ES.yml
+++ b/src/main/resources/locale/translation-ES_ES.yml
@@ -34,9 +34,9 @@ messages:
   help:
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="
     - " "
-    - "<white>[+] <gray>/money [username] <white>- <gray>Mostrar el saldo de tu cuenta o de otro jugador"
     - "<white>[+] <gray>/money help <white>- <gray>Mostrar lista de comandos"
     - "<white>[+] <gray>/money top [page] <white>- <gray>Mostrar jugadores mas ricos"
+    - "<white>[+] <gray>/money bal [username] <white>- <gray>Mostrar el saldo de tu cuenta o de otro jugador"
     - "<white>[+] <gray>/money pay <yellow><username> <amount> <white>- <gray>Transferir dinero a otro jugador."
     - " "
     - "<green>===========<white>[<green>LITE_ECO<white>]<green>==========="

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,7 @@ permissions:
     children:
       lite.eco.help: true
       lite.eco.money: true
+      lite.eco.balance: true
       lite.eco.top: true
       lite.eco.pay: true
   lite.eco.admin:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,14 +27,14 @@ permissions:
   lite.eco.admin:
     description: Gives access to all admin commands
     children:
-      lite.eco.admin.help: true
       lite.eco.suggestion.players: true
-      lite.eco.add: true
-      lite.eco.gadd: true
-      lite.eco.set: true
-      lite.eco.gset: true
-      lite.eco.remove: true
-      lite.eco.gremove: true
-      lite.eco.lang: true
-      lite.eco.purge: true
-      lite.eco.reload: true
+      lite.eco.admin.help: true
+      lite.eco.admin.add: true
+      lite.eco.admin.gadd: true
+      lite.eco.admin.set: true
+      lite.eco.admin.gset: true
+      lite.eco.admin.remove: true
+      lite.eco.admin.gremove: true
+      lite.eco.admin.lang: true
+      lite.eco.admin.purge: true
+      lite.eco.admin.reload: true


### PR DESCRIPTION
**Command scheme**

- /money _(Usage)_
- /money help
- /money bal [player]
   • /bal
   • /balance
- /money top [page]
   • /baltop
- /money pay \<player> \<amount>
   • /pay

**Permission changes**
- Moved admin permissions to `lite.eco.admin.{child}`
- Added `lite.eco.balance`

**Includes Upstream changes from** _([main](https://github.com/LcyDev/LiteEco/tree/main))_

Feedback? I'm trying to achieve a more refined command usage and i think this is pretty good

Idk what to do with the main commands (`/money`, `/eco`)
Currently it just shows the usage but maybe it should show help?
 