### PR TITLE
[Feature]: Add compact representations for input/output.

### DIFF
--- a/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
@@ -54,6 +54,7 @@ class PlaceHolderExtensionProvider(private val liteEco: LiteEco) : PlaceholderEx
         return when(identifier) {
             "balance" -> liteEco.api.getBalance(player).toString()
             "balance_formatted" -> liteEco.api.formatting(liteEco.api.getBalance(player))
+            "balance_compact" -> liteEco.api.compactFormat(liteEco.api.getBalance(player))
             "top_rank_player" -> nameByRank(1)
             else -> null
         }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
@@ -52,6 +52,10 @@ class LiteEcoEconomyAPI(private val liteEco: LiteEco) : LiteEconomyAPIProvider {
         return liteEco.preparedStatements.getTopBalance()
     }
 
+    override fun compactFormat(amount: Double): String {
+        return amount.moneyFormat(true)
+    }
+
     override fun formatting(amount: Double): String {
         return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString(), liteEco.config.getString("plugin.economy.compact_display").toBoolean())
     }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
@@ -53,6 +53,6 @@ class LiteEcoEconomyAPI(private val liteEco: LiteEco) : LiteEconomyAPIProvider {
     }
 
     override fun formatting(amount: Double): String {
-        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString())
+        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString(), liteEco.config.getString("plugin.economy.compact_display").toBoolean())
     }
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/interfaces/LiteEconomyAPIProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/interfaces/LiteEconomyAPIProvider.kt
@@ -81,4 +81,5 @@ interface LiteEconomyAPIProvider {
      */
     fun formatting(amount: Double): String
 
+    fun compactFormat(amount: Double): String
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -225,7 +225,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
         @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer,
         @Argument(value = "amount") amountStr: String
     ) {
-        val amount = validateAmount(amountStr, commandSender) ?: return
+        val amount = validateAmount(amountStr, commandSender, ErrorLevel.ONLY_NEGATIVE) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
@@ -244,7 +244,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
         commandSender: CommandSender,
         @Argument("amount") @Range(min = "1.0", max = "") amountStr: String
     ) {
-        val amount = validateAmount(amountStr, commandSender) ?: return
+        val amount = validateAmount(amountStr, commandSender, ErrorLevel.ONLY_NEGATIVE) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -13,7 +13,7 @@ import encryptsl.cekuj.net.extensions.isNegative
 import encryptsl.cekuj.net.extensions.isZero
 import encryptsl.cekuj.net.extensions.moneyFormat
 import encryptsl.cekuj.net.extensions.positionIndexed
-import encryptsl.cekuj.net.extensions.toValidNumber
+import encryptsl.cekuj.net.extensions.parseValidNumber
 import encryptsl.cekuj.net.utils.MigrationData
 import encryptsl.cekuj.net.utils.MigrationTool
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
@@ -35,10 +35,10 @@ class MoneyCMD(private val liteEco: LiteEco) {
     }
 
     private fun validateAmount(amountStr: String, commandSender: CommandSender, errorLevel: ErrorLevel = ErrorLevel.FULL_ERROR): Double? {
-        val amount = amountStr.toValidNumber()
+        val amount = amountStr.parseValidNumber()
 
         if (amount == null) {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.format.amount.error")))
+            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.format_amount_error")))
             return null
         }
 

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -35,11 +35,7 @@ private fun compactNumber(number: Double): Pair<Double, Char>? {
         unitIndex++
     }
 
-    return if (unitIndex > 0) {
-        Pair(value, units[unitIndex - 1])
-    } else {
-        null
-    }
+    return unitIndex.takeIf { it > 0 }?.let { Pair(value, units[it - 1]) }
 }
 
 fun String.parseValidNumber(): Double? {
@@ -48,11 +44,11 @@ fun String.parseValidNumber(): Double? {
     val lastChar = this.lastOrNull()?.uppercaseChar()
     val multiplier = units.getOrDefault(lastChar, 1.0)
     if (multiplier == 1.0) {
-        return if (this.isNumeric()) this.toDoubleOrNull() else null
+        return if (this.isDecimal()) this.toDoubleOrNull() else null
     }
 
     val str = dropLast(1)
-    val value = if (str.isNumeric()) str.toDoubleOrNull() else null
+    val value = if (str.isDecimal()) str.toDoubleOrNull() else null
 
     return value?.times(multiplier)
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -52,8 +52,8 @@ fun String.toValidNumber(): Double? {
     if (lastChar == null || !units.containsKey(lastChar)) {
         return toDoubleOrNull()
     }
-    val multiplier = units[lastChar]!!
-    val value = dropLast(1).toDoubleOrNull()!!
+    val multiplier = units[lastChar]
+    val value = dropLast(1).toDoubleOrNull()
 
-    return value * multiplier
+    return value?.times(multiplier!!)
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -3,13 +3,14 @@ package encryptsl.cekuj.net.extensions
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
+import java.util.logging.Logger
 
 fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
     val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
     formatter.maximumFractionDigits = 2
 
     val compactData = if (compact) compactNumber(this) else null
-    val (number, compactChar) = compactData ?: this to ""
+    val (number, compactChar) = compactData ?: (this to "")
     val suffix = "$compactChar $currencyName"
 
     return "$prefix${formatter.format(number)}$suffix"
@@ -22,7 +23,7 @@ fun Double.moneyFormat(): String {
 }
 
 private fun compactNumber(number: Double): Pair<Double, Char>? {
-    val units = charArrayOf('K', 'M', 'B', 'T')
+    val units = charArrayOf('K', 'M', 'B', 'T', 'Q')
 
     if (number < 1000) {
         return null
@@ -41,14 +42,13 @@ private fun compactNumber(number: Double): Pair<Double, Char>? {
 fun String.parseValidNumber(): Double? {
     val units = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0, 'Q' to 1_000_000_000_000_000.0)
 
-    val lastChar = this.lastOrNull()?.uppercaseChar()
+    val lastChar = lastOrNull()?.uppercaseChar()
     val multiplier = units.getOrDefault(lastChar, 1.0)
     if (multiplier == 1.0) {
-        return if (this.isDecimal()) this.toDoubleOrNull() else null
+        return takeIf { it.isDecimal() }?.toDoubleOrNull()
     }
 
-    val str = dropLast(1)
-    val value = if (str.isDecimal()) str.toDoubleOrNull() else null
+    val value = dropLast(1).takeIf { it.isDecimal() }?.toDoubleOrNull()
 
     return value?.times(multiplier)
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -3,31 +3,41 @@ package encryptsl.cekuj.net.extensions
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
-import java.util.logging.Logger
 
-fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
+
+private fun formatter(): DecimalFormat {
     val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
     formatter.maximumFractionDigits = 2
-
-    val compactData = if (compact) compactNumber(this) else null
-    val (number, compactChar) = compactData ?: (this to "")
-    val suffix = "$compactChar $currencyName"
-
-    return "$prefix${formatter.format(number)}$suffix"
+    return formatter
 }
 
-fun Double.moneyFormat(): String {
-    val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
-    formatter.maximumFractionDigits = 2
-    return formatter.format(this)
+private fun formatNumber(number: Double, compact: Boolean): Pair<String, Char?> {
+    return if (compact) {
+        val (compactNumber, compactChar) = compactNumber(number) ?: (number to null)
+        formatter().format(compactNumber) to compactChar
+    } else {
+        formatter().format(number) to null
+    }
+}
+
+fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
+    val (formattedNumber, compactChar) = formatNumber(this, compact)
+    val suffix = compactChar?.let { " $it $currencyName" } ?: " $currencyName"
+
+    return "$prefix$formattedNumber$suffix"
+}
+
+fun Double.moneyFormat(compact: Boolean = false): String {
+    val (formattedNumber, compactChar) = formatNumber(this, compact)
+    val suffix = compactChar?.let { " $it" } ?: ""
+
+    return "$formattedNumber$suffix"
 }
 
 private fun compactNumber(number: Double): Pair<Double, Char>? {
     val units = charArrayOf('K', 'M', 'B', 'T', 'Q')
 
-    if (number < 1000) {
-        return null
-    }
+    if (number < 1000) return null
 
     var unitIndex = 0
     var value = number

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -4,10 +4,18 @@ import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
 
-fun Double.moneyFormat(prefix: String, currencyName: String): String {
-    val formatter = DecimalFormat("$prefix###,###,##0.00 $currencyName", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
+    val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
     formatter.maximumFractionDigits = 2
-    return formatter.format(this)
+
+    val compactData = toCompact(this)
+    val number = compactData?.first ?: this
+    var suffix = " $currencyName"
+    if (compact) {
+        suffix = compactData?.second?.toString() + suffix
+    }
+
+    return "$prefix${formatter.format(number)}$suffix"
 }
 
 fun Double.moneyFormat(): String {
@@ -15,15 +23,37 @@ fun Double.moneyFormat(): String {
     formatter.maximumFractionDigits = 2
     return formatter.format(this)
 }
+
+private fun toCompact(number: Double): Pair<Double, Char>? {
+    val units = charArrayOf('K', 'M', 'B', 'T')
+
+    if (number < 1000) {
+        return null
+    }
+
+    var unitIndex = 0
+    var value = number
+    while (value >= 1000 && unitIndex < units.size) {
+        value /= 1000
+        unitIndex++
+    }
+
+    return if (unitIndex > 0) {
+        Pair(value, units[unitIndex - 1])
+    } else {
+        null
+    }
+}
+
 fun String.toValidNumber(): Double? {
-    val units = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0)
+    val units = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0, 'Q' to 1_000_000_000_000_000.0)
 
     val lastChar = this.lastOrNull()?.uppercaseChar()
     if (lastChar == null || !units.containsKey(lastChar)) {
         return toDoubleOrNull()
     }
     val multiplier = units[lastChar]!!
-    val value = dropLast(1)?.toDoubleOrNull()!!
+    val value = dropLast(1).toDoubleOrNull()!!
 
     return value * multiplier
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -1,39 +1,56 @@
 package encryptsl.cekuj.net.extensions
 
+import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
 
 
-private fun formatter(): DecimalFormat {
-    val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
-    formatter.maximumFractionDigits = 2
+private fun formatter(fractionDigits: Int = 2, roundingMode: RoundingMode): DecimalFormat {
+    val formatter = DecimalFormat("###,###,##0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+    formatter.maximumFractionDigits = fractionDigits
+    formatter.roundingMode = roundingMode
     return formatter
 }
 
 private fun formatNumber(number: Double, compact: Boolean): Pair<String, Char?> {
     return if (compact) {
         val (compactNumber, compactChar) = compactNumber(number) ?: (number to null)
-        formatter().format(compactNumber) to compactChar
+        removeTrailingZeros(formatter(roundingMode = RoundingMode.DOWN).format(compactNumber)) to compactChar
     } else {
-        formatter().format(number) to null
+        formatter(roundingMode = RoundingMode.HALF_UP).format(number) to null
     }
 }
 
 fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
     val (formattedNumber, compactChar) = formatNumber(this, compact)
-    val suffix = compactChar?.let { " $it $currencyName" } ?: " $currencyName"
+    val suffix = compactChar?.let { "$it $currencyName" } ?: " $currencyName"
 
     return "$prefix$formattedNumber$suffix"
 }
 
 fun Double.moneyFormat(compact: Boolean = false): String {
     val (formattedNumber, compactChar) = formatNumber(this, compact)
-    val suffix = compactChar?.let { " $it" } ?: ""
+    val suffix = compactChar?.let { "$it" } ?: ""
 
     return "$formattedNumber$suffix"
 }
 
+private fun removeTrailingZeros(numberStr: String): String {
+    return if (numberStr.contains('.') && numberStr.endsWith("0")) {
+        var i = numberStr.length - 1
+        while (i >= 0 && numberStr[i] == '0') {
+            i--
+        }
+        if (numberStr[i] == '.') {
+            numberStr.substring(0, i)
+        } else {
+            numberStr.substring(0, i + 1)
+        }
+    } else {
+        numberStr
+    }
+}
 private fun compactNumber(number: Double): Pair<Double, Char>? {
     val units = charArrayOf('K', 'M', 'B', 'T', 'Q')
 

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -15,3 +15,15 @@ fun Double.moneyFormat(): String {
     formatter.maximumFractionDigits = 2
     return formatter.format(this)
 }
+fun String.toValidNumber(): Double? {
+    val units = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0)
+
+    val lastChar = this.lastOrNull()?.uppercaseChar()
+    if (lastChar == null || !units.containsKey(lastChar)) {
+        return toDoubleOrNull()
+    }
+    val multiplier = units[lastChar]!!
+    val value = dropLast(1)?.toDoubleOrNull()!!
+
+    return value * multiplier
+}

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
@@ -11,3 +11,9 @@ fun String.isNumeric(): Boolean {
     if (this.isEmpty()) return false
     return this.toIntOrNull() != null
 }
+
+fun String.isDecimal(): Boolean {
+    if (this.isEmpty()) return false
+    val value = this.toDoubleOrNull()
+    return value != null && !value.isFinite()
+}

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
@@ -8,12 +8,9 @@ fun Double.isZero(): Boolean {
     return this == 0.0
 }
 fun String.isNumeric(): Boolean {
-    if (this.isEmpty()) return false
     return this.toIntOrNull() != null
 }
 
 fun String.isDecimal(): Boolean {
-    if (this.isEmpty()) return false
-    val value = this.toDoubleOrNull()
-    return value != null && !value.isFinite()
+    return toDoubleOrNull()?.takeIf { it.isFinite() } != null
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,8 @@ plugin:
     name: LE
     # This amount is added to player from first connection.
     default_money: 30
+    # Convert big numbers into a more compact display.
+    compact_display: false
   # These settings disable messages.
   disableMessages:
     g_broadcast_pay: false

--- a/src/main/resources/locale/cs_cz.yml
+++ b/src/main/resources/locale/cs_cz.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>Stav účtu <target> je <green><money><white> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Jméno hráče musí být vyplněno !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Detekovano negativní číslo !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Neplatná částka. Použijte desetinná čísla nebo kompaktní zobrazení (např. 1K) !" # TEMP #
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>Nemáš dostatek peněz !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>Poslal jsi <green><target> <money> <white>peněz."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>vám poslal <green><money> <white>peněz."

--- a/src/main/resources/locale/en_us.yml
+++ b/src/main/resources/locale/en_us.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>Status of <target> balance is <green><money><white> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Player name must be filled !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Detected negative number !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Invalid amount. Use float numbers or compact representations (e.g 1K) !"
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>You don't have enough money !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>You sent to <green><target> <money> <white>money."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>sent you <green><money> <white>money."

--- a/src/main/resources/locale/es_es.yml
+++ b/src/main/resources/locale/es_es.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>El saldo de <gold><target></gold> es de <green><money></green> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Debes especificar un jugador !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Introduce un valor positivo !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Cantidad invalida. Utiliza numeros decimales o representaciones compactas (ej. 1K) !"
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>No tienes suficiente dinero !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>Enviaste <green><money></green> a <gold><target>."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <white>Recibiste <green><money></green> de <gold><sender>."

--- a/src/main/resources/locale/ja_jp.yml
+++ b/src/main/resources/locale/ja_jp.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white><target>の所持金は<green><money><white>"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>プレイヤー名を入力してください。"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>マイナスの金額は入力できません。"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>無効な金額です。小数点を使用するか、コンパクトな表記（例：1K）を利用してください。" # TEMP #
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>お金が足りていません。"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white><green><target><white>へ<green><money> <white>送金しました。"
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>から<green><money> <white>送金されました。"


### PR DESCRIPTION
 * #52 ✅
 
 * Implemented compact representations for input with `validateAmount()`.
 * Implemented compact representations for output/display in `liteEco.api.formatting()`
 * Refactored repeated code for amount validation with `validateAmount()`
 * Implemented temporal translation for `format_amount_error`
 * Added config `plugin.economy.compact_display` to toggle compact representations for output.