### PR TITLE
[Feature]: Add support for compact representations in input and output

### DIFF
--- a/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
@@ -54,6 +54,7 @@ class PlaceHolderExtensionProvider(private val liteEco: LiteEco) : PlaceholderEx
 
         return when(identifier) {
             "balance" -> liteEco.api.getBalance(player).toString()
+            "balance_compacted" -> liteEco.api.compacted(liteEco.api.getBalance(player))
             "balance_formatted" -> liteEco.api.formatting(liteEco.api.getBalance(player))
             "top_rank_player" -> nameByRank(1)
             else -> null

--- a/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
@@ -1,6 +1,7 @@
 package encryptsl.cekuj.net.api
 
 import encryptsl.cekuj.net.LiteEco
+import encryptsl.cekuj.net.extensions.isDecimal
 import encryptsl.cekuj.net.extensions.isNumeric
 import encryptsl.cekuj.net.extensions.playerPosition
 import me.clip.placeholderapi.expansion.PlaceholderExpansion
@@ -32,17 +33,17 @@ class PlaceHolderExtensionProvider(private val liteEco: LiteEco) : PlaceholderEx
 
         if (identifier.startsWith("top_formatted_")) {
             val split = this.spliterator(identifier, 2)
-            return if (split.isNumeric()) liteEco.api.formatting(balanceByRank(split.toInt())) else null
+            return if (split.isDecimal()) liteEco.api.formatting(balanceByRank(split.toInt())) else null
         }
 
         if (identifier.startsWith("top_balance_")) {
             val split = this.spliterator(identifier, 2)
-            return if (split.isNumeric()) balanceByRank(split.toInt()).toString() else null
+            return if (split.isDecimal()) balanceByRank(split.toInt()).toString() else null
         }
 
         if (identifier.startsWith("top_player_")) {
             val split = this.spliterator(identifier, 2)
-            return if (!split.isNumeric()) {
+            return if (!split.isDecimal()) {
                 null
             } else if (nameByRank(split.toInt()) == "EMPTY") {
                 nameByRank(split.toInt())
@@ -84,7 +85,7 @@ class PlaceHolderExtensionProvider(private val liteEco: LiteEco) : PlaceholderEx
     }
 
     private fun topBalance(): LinkedHashMap<String, Double>? {
-          return liteEco.api.getTopBalance()
+        return liteEco.api.getTopBalance()
             .entries
             .stream()
             .filter { data -> Bukkit.getOfflinePlayer(UUID.fromString(data.key)).hasPlayedBefore() }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/PlaceHolderExtensionProvider.kt
@@ -2,7 +2,6 @@ package encryptsl.cekuj.net.api
 
 import encryptsl.cekuj.net.LiteEco
 import encryptsl.cekuj.net.extensions.isDecimal
-import encryptsl.cekuj.net.extensions.isNumeric
 import encryptsl.cekuj.net.extensions.playerPosition
 import me.clip.placeholderapi.expansion.PlaceholderExpansion
 import org.bukkit.Bukkit

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
@@ -52,7 +52,11 @@ class LiteEcoEconomyAPI(private val liteEco: LiteEco) : LiteEconomyAPIProvider {
         return liteEco.preparedStatements.getTopBalance()
     }
 
+    override fun compacted(amount: Double): String {
+        return amount.moneyFormat(true)
+    }
+
     override fun formatting(amount: Double): String {
-        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString())
+        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString(), liteEco.config.getString("plugin.economy.compact_display").toBoolean())
     }
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/LiteEcoEconomyAPI.kt
@@ -57,6 +57,6 @@ class LiteEcoEconomyAPI(private val liteEco: LiteEco) : LiteEconomyAPIProvider {
     }
 
     override fun formatting(amount: Double): String {
-        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString(), liteEco.config.getString("plugin.economy.compact_display").toBoolean())
+        return amount.moneyFormat(liteEco.config.getString("plugin.economy.prefix").toString(), liteEco.config.getString("plugin.economy.name").toString(), liteEco.config.getBoolean("plugin.economy.compact_display"))
     }
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/treasury/TreasuryAccount.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/treasury/TreasuryAccount.kt
@@ -1,6 +1,7 @@
 package encryptsl.cekuj.net.api.economy.treasury
 
 import encryptsl.cekuj.net.LiteEco
+import encryptsl.cekuj.net.extensions.isApproachingZero
 import encryptsl.cekuj.net.extensions.isNegative
 import encryptsl.cekuj.net.extensions.isZero
 import encryptsl.cekuj.net.extensions.moneyFormat
@@ -48,7 +49,7 @@ class TreasuryAccount(private val liteEco: LiteEco, private val uuid: UUID) : Pl
                 return@Runnable
             }
 
-            if (amountDouble.isNegative() || amountDouble.isZero() || amountDouble.moneyFormat() == "0.00") {
+            if (amountDouble.isApproachingZero()) {
                 subscription.fail(EconomyException(EconomyFailureReason.NEGATIVE_AMOUNT_SPECIFIED))
                 return@Runnable
             }
@@ -68,7 +69,7 @@ class TreasuryAccount(private val liteEco: LiteEco, private val uuid: UUID) : Pl
             val amount = economyTransaction.transactionAmount
             val amountDouble = amount.toDouble()
 
-            if (amountDouble.isNegative() || amountDouble.isZero() || amountDouble.moneyFormat() == "0.00") {
+            if (amountDouble.isApproachingZero()) {
                 subscription.fail(EconomyException(EconomyFailureReason.NEGATIVE_AMOUNT_SPECIFIED))
                 return@Runnable
             }

--- a/src/main/kotlin/encryptsl/cekuj/net/api/economy/vault/AdaptiveEconomyVaultAPI.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/economy/vault/AdaptiveEconomyVaultAPI.kt
@@ -1,6 +1,7 @@
 package encryptsl.cekuj.net.api.economy.vault
 
 import encryptsl.cekuj.net.LiteEco
+import encryptsl.cekuj.net.extensions.isApproachingZero
 import encryptsl.cekuj.net.extensions.isNegative
 import encryptsl.cekuj.net.extensions.isZero
 import encryptsl.cekuj.net.extensions.moneyFormat
@@ -98,7 +99,7 @@ class AdaptiveEconomyVaultAPI(private val liteEco: LiteEco) : AbstractEconomy() 
         if (player == null) {
             return EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, null)
         }
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
+        if (amount.isApproachingZero()) {
             return EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, null)
         }
 
@@ -129,7 +130,7 @@ class AdaptiveEconomyVaultAPI(private val liteEco: LiteEco) : AbstractEconomy() 
             return EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, null)
         }
 
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
+        if (amount.isApproachingZero()) {
             return EconomyResponse(0.0, 0.0, EconomyResponse.ResponseType.FAILURE, null)
         }
 

--- a/src/main/kotlin/encryptsl/cekuj/net/api/enums/CheckLevel.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/enums/CheckLevel.kt
@@ -1,0 +1,6 @@
+package encryptsl.cekuj.net.api.enums
+
+enum class CheckLevel {
+    FULL,
+    ONLY_NEGATIVE,
+}

--- a/src/main/kotlin/encryptsl/cekuj/net/api/interfaces/LiteEconomyAPIProvider.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/api/interfaces/LiteEconomyAPIProvider.kt
@@ -75,6 +75,13 @@ interface LiteEconomyAPIProvider {
     fun getTopBalance(): MutableMap<String, Double>
 
     /**
+     * Compact money value
+     * @param amount is only formatted to a compacted value
+     * @return String
+     */
+    fun compacted(amount: Double): String
+
+    /**
      * Formatting money value
      * @param amount is formatted to readable value
      * @return String

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -10,11 +10,7 @@ import encryptsl.cekuj.net.api.enums.MigrationKey
 import encryptsl.cekuj.net.api.enums.PurgeKey
 import encryptsl.cekuj.net.api.events.*
 import encryptsl.cekuj.net.api.objects.ModernText
-import encryptsl.cekuj.net.extensions.isNegative
-import encryptsl.cekuj.net.extensions.isZero
-import encryptsl.cekuj.net.extensions.moneyFormat
-import encryptsl.cekuj.net.extensions.positionIndexed
-import encryptsl.cekuj.net.extensions.toValidDecimal
+import encryptsl.cekuj.net.extensions.*
 import encryptsl.cekuj.net.utils.MigrationData
 import encryptsl.cekuj.net.utils.MigrationTool
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
@@ -37,7 +33,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
             return null
         }
         if (checkLevel == CheckLevel.ONLY_NEGATIVE && amount.isNegative() ||
-            checkLevel == CheckLevel.FULL && (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00")
+            checkLevel == CheckLevel.FULL && (amount.isApproachingZero())
         ) {
             commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
             return null

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -14,7 +14,7 @@ import encryptsl.cekuj.net.extensions.isNegative
 import encryptsl.cekuj.net.extensions.isZero
 import encryptsl.cekuj.net.extensions.moneyFormat
 import encryptsl.cekuj.net.extensions.positionIndexed
-import encryptsl.cekuj.net.extensions.parseValidNumber
+import encryptsl.cekuj.net.extensions.toValidDecimal
 import encryptsl.cekuj.net.utils.MigrationData
 import encryptsl.cekuj.net.utils.MigrationTool
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
@@ -31,7 +31,7 @@ import java.util.*
 class MoneyCMD(private val liteEco: LiteEco) {
 
     private fun validateAmount(amountStr: String, commandSender: CommandSender, checkLevel: CheckLevel = CheckLevel.FULL): Double? {
-        val amount = amountStr.parseValidNumber()
+        val amount = amountStr.toValidDecimal()
         if (amount == null) {
             commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.format_amount_error")))
             return null

--- a/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/commands/MoneyCMD.kt
@@ -4,6 +4,7 @@ import cloud.commandframework.annotations.*
 import cloud.commandframework.annotations.specifier.Range
 import encryptsl.cekuj.net.LiteEco
 import encryptsl.cekuj.net.api.Paginator
+import encryptsl.cekuj.net.api.enums.CheckLevel
 import encryptsl.cekuj.net.api.enums.LangKey
 import encryptsl.cekuj.net.api.enums.MigrationKey
 import encryptsl.cekuj.net.api.enums.PurgeKey
@@ -13,6 +14,7 @@ import encryptsl.cekuj.net.extensions.isNegative
 import encryptsl.cekuj.net.extensions.isZero
 import encryptsl.cekuj.net.extensions.moneyFormat
 import encryptsl.cekuj.net.extensions.positionIndexed
+import encryptsl.cekuj.net.extensions.parseValidNumber
 import encryptsl.cekuj.net.utils.MigrationData
 import encryptsl.cekuj.net.utils.MigrationTool
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
@@ -27,6 +29,22 @@ import java.util.*
 @Suppress("UNUSED")
 @CommandDescription("Provided plugin by LiteEco")
 class MoneyCMD(private val liteEco: LiteEco) {
+
+    private fun validateAmount(amountStr: String, commandSender: CommandSender, checkLevel: CheckLevel = CheckLevel.FULL): Double? {
+        val amount = amountStr.parseValidNumber()
+        if (amount == null) {
+            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.format_amount_error")))
+            return null
+        }
+        if (checkLevel == CheckLevel.ONLY_NEGATIVE && amount.isNegative() ||
+            checkLevel == CheckLevel.FULL && (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00")
+        ) {
+            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
+            return null
+        }
+        return amount
+    }
+
 
     @CommandMethod("money help")
     @CommandPermission("lite.eco.help")
@@ -140,7 +158,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
     fun onPayMoney(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer,
-        @Argument(value = "amount") @Range(min = "1.00", max = "") amount: Double
+        @Argument(value = "amount") @Range(min = "1.00", max = "") amountStr: String
     ) {
         if (commandSender is Player) {
             if (commandSender.name == offlinePlayer.name) {
@@ -148,10 +166,7 @@ class MoneyCMD(private val liteEco: LiteEco) {
                 return
             }
 
-            if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
-                commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-                return
-            }
+            val amount = validateAmount(amountStr, commandSender) ?: return
 
             liteEco.server.scheduler.runTask(liteEco) { ->
                 liteEco.pluginManger.callEvent(PlayerEconomyPayEvent(commandSender, offlinePlayer, amount))
@@ -174,13 +189,9 @@ class MoneyCMD(private val liteEco: LiteEco) {
     fun onAddMoney(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer,
-        @Argument(value = "amount") @Range(min = "1.00", max = "") amount: Double
+        @Argument(value = "amount") @Range(min = "1.00", max = "") amountStr: String
     ) {
-
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
-        }
+        val amount = validateAmount(amountStr, commandSender) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(AdminEconomyMoneyDepositEvent(commandSender, offlinePlayer, amount))
@@ -191,12 +202,9 @@ class MoneyCMD(private val liteEco: LiteEco) {
     @CommandPermission("lite.eco.admin.gadd")
     fun onGlobalAddMoney(
         commandSender: CommandSender,
-        @Argument("amount") @Range(min = "1.0", max = "") amount: Double
+        @Argument("amount") @Range(min = "1.0", max = "") amountStr: String
     ) {
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
-        }
+        val amount = validateAmount(amountStr, commandSender) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
@@ -210,12 +218,10 @@ class MoneyCMD(private val liteEco: LiteEco) {
     fun onSetBalance(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer,
-        @Argument(value = "amount") amount: Double
+        @Argument(value = "amount") amountStr: String
     ) {
-        if (amount.isNegative()) {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
-        }
+        val amount = validateAmount(amountStr, commandSender, CheckLevel.ONLY_NEGATIVE) ?: return
+
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
                 AdminEconomyMoneySetEvent(
@@ -231,12 +237,9 @@ class MoneyCMD(private val liteEco: LiteEco) {
     @CommandPermission("lite.eco.admin.gset")
     fun onGlobalSetMoney(
         commandSender: CommandSender,
-        @Argument("amount") @Range(min = "1.0", max = "") amount: Double
+        @Argument("amount") @Range(min = "1.0", max = "") amountStr: String
     ) {
-        if (amount.isNegative()) {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
-        }
+        val amount = validateAmount(amountStr, commandSender, CheckLevel.ONLY_NEGATIVE) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
@@ -250,13 +253,9 @@ class MoneyCMD(private val liteEco: LiteEco) {
     fun onRemoveMoney(
         commandSender: CommandSender,
         @Argument(value = "player", suggestions = "players") offlinePlayer: OfflinePlayer,
-        @Argument(value = "amount") @Range(min = "1.00", max = "") amount: Double
+        @Argument(value = "amount") @Range(min = "1.00", max = "") amountStr: String
     ) {
-
-        if (amount.isNegative() || amount.isZero() || amount.moneyFormat() == "0.00") {
-            commandSender.sendMessage(ModernText.miniModernText(liteEco.translationConfig.getMessage("messages.negative_amount_error")))
-            return
-        }
+        val amount = validateAmount(amountStr, commandSender) ?: return
 
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
@@ -273,8 +272,10 @@ class MoneyCMD(private val liteEco: LiteEco) {
     @CommandPermission("lite.eco.admin.gremove")
     fun onGlobalRemoveMoney(
         commandSender: CommandSender,
-        @Argument("amount") @Range(min = "1.0", max = "") amount: Double
+        @Argument("amount") @Range(min = "1.0", max = "") amountStr: String
     ) {
+        val amount = validateAmount(amountStr, commandSender) ?: return
+
         liteEco.server.scheduler.runTask(liteEco) { ->
             liteEco.pluginManger.callEvent(
                 AdminEconomyGlobalWithdrawEvent(commandSender, amount)

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -1,17 +1,80 @@
 package encryptsl.cekuj.net.extensions
-
+import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
 
-fun Double.moneyFormat(prefix: String, currencyName: String): String {
-    val formatter = DecimalFormat("$prefix###,###,##0.00 $currencyName", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
-    formatter.maximumFractionDigits = 2
-    return formatter.format(this)
+private val units = charArrayOf('K', 'M', 'B', 'T', 'Q')
+private val unitsMap = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0, 'Q' to 1_000_000_000_000_000.0)
+
+
+fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
+    val (formattedNumber, compactChar) = formatNumber(this, compact)
+    val suffix = compactChar?.let { "$it $currencyName" } ?: " $currencyName"
+    return "$prefix$formattedNumber$suffix"
 }
 
-fun Double.moneyFormat(): String {
-    val formatter = DecimalFormat("###,###,##0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
-    formatter.maximumFractionDigits = 2
-    return formatter.format(this)
+fun Double.moneyFormat(compact: Boolean = false): String {
+    val (formattedNumber, compactChar) = formatNumber(this, compact)
+    val suffix = compactChar?.let { "$it" } ?: ""
+    return "$formattedNumber$suffix"
+}
+
+fun String.parseValidNumber(): Double? {
+    if (isNullOrBlank()) return null
+    val lastChar = last().uppercaseChar()
+    return if (units.contains(lastChar)) {
+        decompressNumber(this, lastChar)
+    } else {
+        toDecimal()
+    }
+}
+
+private fun formatNumber(number: Double, compact: Boolean): Pair<String, Char?> {
+    return if (compact) {
+        val (compactNumber, compactChar) = compactNumber(number) ?: (number to null)
+        removeTrailingZeros(formatter(roundingMode = RoundingMode.DOWN).format(compactNumber)) to compactChar
+    } else {
+        formatter(roundingMode = RoundingMode.HALF_UP).format(number) to null
+    }
+}
+
+private fun formatter(fractionDigits: Int = 2, roundingMode: RoundingMode): DecimalFormat {
+    val formatter = DecimalFormat("###,###,##0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+    formatter.maximumFractionDigits = fractionDigits
+    formatter.roundingMode = roundingMode
+    return formatter
+}
+
+private fun removeTrailingZeros(numberStr: String): String {
+    return if (numberStr.contains('.') && numberStr.endsWith("0")) {
+        var i = numberStr.length - 1
+        while (i >= 0 && numberStr[i] == '0') {
+            i--
+        }
+        if (numberStr[i] == '.') {
+            numberStr.substring(0, i)
+        } else {
+            numberStr.substring(0, i + 1)
+        }
+    } else {
+        numberStr
+    }
+}
+
+private fun decompressNumber(str: String, metric: Char): Double? {
+    val multiplier = unitsMap[metric] ?: 1.0
+    val value = str.dropLast(1).toDecimal()
+    return value?.times(multiplier)
+}
+
+private fun compactNumber(number: Double): Pair<Double, Char>? {
+    if (number < 1000) return null
+    var unitIndex = 0
+    var value = number
+    while (value >= 1000 && unitIndex < units.size) {
+        value /= 1000
+        unitIndex++
+    }
+    return unitIndex.takeIf { it > 0 }?.let { Pair(value, units[it - 1]) }
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -32,13 +32,13 @@ fun String.toValidDecimal(): Double? {
 private fun formatNumber(number: Double, compact: Boolean): Pair<String, Char?> {
     return if (compact) {
         val (compactNumber, compactChar) = compactNumber(number) ?: (number to null)
-        removeTrailingZeros(formatter(roundingMode = RoundingMode.DOWN).format(compactNumber)) to compactChar
+        removeTrailingZeros(formatter(3, RoundingMode.DOWN).format(compactNumber)) to compactChar
     } else {
-        formatter(roundingMode = RoundingMode.HALF_UP).format(number) to null
+        formatter(2, RoundingMode.HALF_UP).format(number) to null
     }
 }
 
-private fun formatter(fractionDigits: Int = 2, roundingMode: RoundingMode): DecimalFormat {
+private fun formatter(fractionDigits: Int, roundingMode: RoundingMode): DecimalFormat {
     val formatter = DecimalFormat("###,###,##0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
     formatter.maximumFractionDigits = fractionDigits
     formatter.roundingMode = roundingMode

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/MoneyFormat.kt
@@ -3,10 +3,9 @@ import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.*
+import kotlin.math.pow
 
 private val units = charArrayOf('K', 'M', 'B', 'T', 'Q')
-private val unitsMap = mapOf('K' to 1000.0, 'M' to 1_000_000.0, 'B' to 1_000_000_000.0, 'T' to 1_000_000_000_000.0, 'Q' to 1_000_000_000_000_000.0)
-
 
 fun Double.moneyFormat(prefix: String, currencyName: String, compact: Boolean = false): String {
     val (formattedNumber, compactChar) = formatNumber(this, compact)
@@ -20,7 +19,7 @@ fun Double.moneyFormat(compact: Boolean = false): String {
     return "$formattedNumber$suffix"
 }
 
-fun String.parseValidNumber(): Double? {
+fun String.toValidDecimal(): Double? {
     if (isNullOrBlank()) return null
     val lastChar = last().uppercaseChar()
     return if (units.contains(lastChar)) {
@@ -63,7 +62,7 @@ private fun removeTrailingZeros(numberStr: String): String {
 }
 
 private fun decompressNumber(str: String, metric: Char): Double? {
-    val multiplier = unitsMap[metric] ?: 1.0
+    val multiplier = 10.0.pow((units.indexOf(metric) + 1) * 3)
     val value = str.dropLast(1).toDecimal()
     return value?.times(multiplier)
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
@@ -8,6 +8,10 @@ fun Double.isZero(): Boolean {
     return this == 0.0
 }
 
+fun Double.isApproachingZero(): Boolean {
+    return this < 0.01
+}
+
 fun String.isDecimal(): Boolean {
     return toDoubleOrNull()?.takeIf { it.isFinite() } != null
 }

--- a/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
+++ b/src/main/kotlin/encryptsl/cekuj/net/extensions/NumberControl.kt
@@ -7,7 +7,11 @@ fun Double.isNegative(): Boolean {
 fun Double.isZero(): Boolean {
     return this == 0.0
 }
-fun String.isNumeric(): Boolean {
-    if (this.isEmpty()) return false
-    return this.toIntOrNull() != null
+
+fun String.isDecimal(): Boolean {
+    return toDoubleOrNull()?.takeIf { it.isFinite() } != null
+}
+
+fun String.toDecimal(): Double? {
+    return toDoubleOrNull()?.takeIf { it.isFinite() }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,8 @@ plugin:
     name: LE
     # This amount is added to player from first connection.
     default_money: 30
+    # Convert big numbers into a more compact display.
+    compact_display: false
   # These settings disable messages.
   disableMessages:
     g_broadcast_pay: false

--- a/src/main/resources/locale/cs_cz.yml
+++ b/src/main/resources/locale/cs_cz.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>Stav účtu <target> je <green><money><white> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Jméno hráče musí být vyplněno !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Detekovano negativní číslo !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Neplatná částka. Použijte desetinná čísla nebo kompaktní zobrazení (např. 1K) !" # TEMP #
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>Nemáš dostatek peněz !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>Poslal jsi <green><target> <money> <white>peněz."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>vám poslal <green><money> <white>peněz."

--- a/src/main/resources/locale/en_us.yml
+++ b/src/main/resources/locale/en_us.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>Status of <target> balance is <green><money><white> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Player name must be filled !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Detected negative number !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Invalid amount. Use float numbers or compact representations (e.g 1K) !"
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>You don't have enough money !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>You sent to <green><target> <money> <white>money."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>sent you <green><money> <white>money."

--- a/src/main/resources/locale/es_es.yml
+++ b/src/main/resources/locale/es_es.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white>El saldo de <gold><target></gold> es de <green><money></green> !"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>Debes especificar un jugador !"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>Introduce un valor positivo !"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>Cantidad invalida. Utiliza numeros decimales o representaciones compactas (ej. 1K) !"
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>No tienes suficiente dinero !"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white>Enviaste <green><money></green> a <gold><target>."
   target_success_pay: "<green>[<white>LITE_ECO<green>] <white>Recibiste <green><money></green> de <gold><sender>."

--- a/src/main/resources/locale/ja_jp.yml
+++ b/src/main/resources/locale/ja_jp.yml
@@ -7,6 +7,7 @@ messages:
   balance_format_target: "<green>[<white>LITE_ECO<green>] <white><target>の所持金は<green><money><white>"
   player_is_null_error: "<green>[<white>LITE_ECO<green>] <red>プレイヤー名を入力してください。"
   negative_amount_error: "<green>[<white>LITE_ECO<green>] <red>マイナスの金額は入力できません。"
+  format_amount_error: "<green>[<white>LITE_ECO<green>] <red>無効な金額です。小数点を使用するか、コンパクトな表記（例：1K）を利用してください。" # TEMP #
   sender_error_enough_pay: "<green>[<white>LITE_ECO<green>] <red>お金が足りていません。"
   sender_success_pay: "<green>[<white>LITE_ECO<green>] <white><green><target><white>へ<green><money> <white>送金しました。"
   target_success_pay: "<green>[<white>LITE_ECO<green>] <green><sender> <white>から<green><money> <white>送金されました。"


### PR DESCRIPTION
This pull request adds support for compact representations, converting large numbers in a more concise format. 

Additionally, the code for amount validation in `MoneyCMD` has been refactored to improve code maintainability.

**About:**
Compact representations are used to abbreviate large numeric values using metric prefixes, to make them more human-readable. Allowing to represent **billions** as `1.5B`

These changes will enhance user experience and it provides better flexibility to manage how numeric values are represented.

**Issues related:**
 * #52 ✅
 
**Changed incorporated:**
 * Implemented compact representations for input and output/display.
 * Compact representations won't round numbers upwards and they can display up to 3 fraction digits.
 * Refactored repeated code for amount validation in `MoneyCMD`
 * Implemented temporal translation for the new entry `format_amount_error`
 * Introduced a configuration option `plugin.economy.compact_display`